### PR TITLE
document tested vectors and add zero-owner test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,16 @@
+# Tested Vectors
+
+## TransferrableOwnership zero-owner initialization
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/TransferrableOwnershipZero.t.sol`
+- Result: Constructor accepts address(0) as owner, leaving contract without an owner and blocking future ownership transfers.
+
+## RelayFacet reentrancy on `swapAndStartBridgeTokensViaRelay`
+- Severity: High
+- Tool: `slither`
+- Result: External calls occur before state mutation of `consumedIds`, enabling reentrancy to reuse a request ID.
+
+## GenericSwapFacetV3 arbitrary ETH transfer
+- Severity: High
+- Tool: `slither`
+- Result: Uses low-level calls to transfer ETH to arbitrary receiver, allowing reentrancy before event emission.

--- a/test/solidity/Security/TransferrableOwnershipZero.t.sol
+++ b/test/solidity/Security/TransferrableOwnershipZero.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {TransferrableOwnership} from "../../../src/Helpers/TransferrableOwnership.sol";
+
+contract TransferrableOwnershipZeroOwnerTest is Test {
+    function testInitialOwnerZeroAllowed() public {
+        TransferrableOwnership t = new TransferrableOwnership(address(0));
+        assertEq(t.owner(), address(0));
+    }
+}


### PR DESCRIPTION
## Summary
- document attack vectors examined during security review
- add regression test for zero-owner initialization in TransferrableOwnership

## Testing
- `forge test --match-path test/solidity/Security/TransferrableOwnershipZero.t.sol`
- `forge test` *(fails: vm.envString: environment variable "ETH_NODE_URI_UNICHAIN" not found)*
- `python -m slither .`


------
https://chatgpt.com/codex/tasks/task_e_68a8df343d84832dbcc741fd8014eda0