### PR TITLE
Add PancakeV3 callback security tests

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,6 @@
+# Tested Vectors
+
+| Date | Description | Severity | Result |
+|------|-------------|----------|--------|
+| 2025-02-14 | Unauthorized PancakeV3 swap callback invocation | High | Reverted with `UniswapV3SwapCallbackUnknownSource` |
+| 2025-02-14 | Zero or negative amount in PancakeV3 swap callback | Medium | Reverted with `UniswapV3SwapCallbackNotPositiveAmount` |


### PR DESCRIPTION
## Summary
- add tests ensuring PancakeV3 swap callbacks reject unauthorized callers and non-positive amounts
- document tested vectors for PancakeV3 callback

## Testing
- `forge test --match-test PancakeV3SwapCallback`

------
https://chatgpt.com/codex/tasks/task_e_68a8df343d84832dbcc741fd8014eda0