### PR TITLE
test: ensure swapTokensGeneric rejects zero receiver

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,5 @@
+# Tested Attack Vectors
+
+| Vector | Severity | Status | Notes |
+| ------ | -------- | ------ | ----- |
+| Using zero address as receiver in swapTokensGeneric | Medium | Mitigated | Reverts with InvalidReceiver; covered by test |

--- a/test/solidity/Facets/GenericSwapFacet.t.sol
+++ b/test/solidity/Facets/GenericSwapFacet.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 import { GenericSwapFacet } from "lifi/Facets/GenericSwapFacet.sol";
 import { LibAllowList, LibSwap, TestBase } from "../utils/TestBase.sol";
+import { InvalidReceiver } from "lifi/Errors/GenericErrors.sol";
 
 // Stub GenericSwapFacet Contract
 contract TestGenericSwapFacet is GenericSwapFacet {
@@ -203,5 +204,28 @@ contract GenericSwapFacetTest is TestBase {
         emit log_named_uint("gas used V1: ", gasUsed);
 
         vm.stopPrank();
+    }
+
+    function test_RevertIfReceiverIsZeroAddress() public {
+        LibSwap.SwapData[] memory swapData = new LibSwap.SwapData[](1);
+        swapData[0] = LibSwap.SwapData({
+            callTo: address(0),
+            approveTo: address(0),
+            sendingAssetId: address(0),
+            receivingAssetId: address(0),
+            fromAmount: 0,
+            callData: "",
+            requiresDeposit: false
+        });
+
+        vm.expectRevert(InvalidReceiver.selector);
+        genericSwapFacet.swapTokensGeneric(
+            "",
+            "",
+            "",
+            payable(address(0)),
+            0,
+            swapData
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add regression test verifying swapTokensGeneric cannot send funds to zero address
- track tested swap receiver vector in TestedVectors.md

## Testing
- `forge test --match-test test_RevertIfReceiverIsZeroAddress -vvv` *(fails: vm.envString: environment variable "ETH_NODE_URI_MAINNET" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df343d84832dbcc741fd8014eda0