### PR TITLE
Add tests for zero address constructor misuse

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -28,3 +28,5 @@
 | Vector | Severity | Status | Notes |
 | ------ | -------- | ------ | ----- |
 | Using zero address as receiver in swapTokensGeneric | Medium | Mitigated | Reverts with InvalidReceiver; covered by test |
+| Missing validation for executor or spokepool zero address in ReceiverAcrossV3 constructor | Medium | Vulnerable | Contract deploys with zero addresses; see test_ConstructorAllowsZeroAddresses |
+| Missing validation for ERC20 proxy zero address in Executor constructor | Medium | Vulnerable | Executor initializes with zero proxy; see test_ConstructorAllowsZeroProxy |

--- a/test/solidity/Security/ExecutorZero.t.sol
+++ b/test/solidity/Security/ExecutorZero.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {Executor} from "lifi/Periphery/Executor.sol";
+
+contract ExecutorZeroAddressTest is Test {
+    function test_ConstructorAllowsZeroProxy() public {
+        Executor e = new Executor(address(0), address(this));
+        assertEq(address(e.erc20Proxy()), address(0));
+    }
+}
+

--- a/test/solidity/Security/ReceiverAcrossV3Zero.t.sol
+++ b/test/solidity/Security/ReceiverAcrossV3Zero.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {ReceiverAcrossV3} from "lifi/Periphery/ReceiverAcrossV3.sol";
+
+contract ReceiverAcrossV3ZeroAddressTest is Test {
+    function test_ConstructorAllowsZeroAddresses() public {
+        ReceiverAcrossV3 r = new ReceiverAcrossV3(address(this), address(0), address(0));
+        assertEq(address(r.executor()), address(0));
+        assertEq(r.spokepool(), address(0));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests covering zero-address constructor parameters for ReceiverAcrossV3 and Executor
- document missing parameter validation in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/ReceiverAcrossV3Zero.t.sol -vvv`
- `forge test --match-path test/solidity/Security/ExecutorZero.t.sol -vvv`


------
https://chatgpt.com/codex/tasks/task_e_68a8e582c6d8832da05fa9085904114f