### PR TITLE
docs: record tested vectors

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -28,3 +28,5 @@
 | Vector | Severity | Status | Notes |
 | ------ | -------- | ------ | ----- |
 | Using zero address as receiver in swapTokensGeneric | Medium | Mitigated | Reverts with InvalidReceiver; covered by test |
+| Permit2 witness call executed by third party | Medium | Mitigated | Execution by unsignatured caller still honors witness; verified with `forge test --match-test test_can_call_diamond_with_permit2_plus_witness` |
+| EIP-7702 delegated account misclassified as EOA | Medium | Mitigated | `LibAsset.isContract` returns false for 23-byte accounts, preventing contract-only interactions; verified with `forge test --match-test test_isContractWithDelegationDesignator` |


### PR DESCRIPTION
## Summary
- document additional tested vectors for Permit2 proxy and EIP-7702 account detection

## Testing
- `forge test --match-test 'test_can_call_diamond_with_permit2_plus_witness|test_isContractWithDelegationDesignator'`


------
https://chatgpt.com/codex/tasks/task_e_68a8e582c6d8832da05fa9085904114f