### PR TITLE
Add test for LibAsset transferFrom approval

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -28,3 +28,4 @@
 | Vector | Severity | Status | Notes |
 | ------ | -------- | ------ | ----- |
 | Using zero address as receiver in swapTokensGeneric | Medium | Mitigated | Reverts with InvalidReceiver; covered by test |
+| Unauthorized transferFrom in LibAsset.transferFromERC20 | Medium | Mitigated | Reverts without prior approval; covered by test |

--- a/test/solidity/Libraries/LibAsset.t.sol
+++ b/test/solidity/Libraries/LibAsset.t.sol
@@ -113,6 +113,17 @@ contract LibAssetTest is TestBase {
         );
     }
 
+    function testRevert_transferFromERC20WithoutApproval() public {
+        vm.expectRevert();
+
+        implementer.transferFromERC20(
+            ADDRESS_USDC,
+            USER_SENDER,
+            payable(makeAddr("Bob")),
+            defaultUSDCAmount
+        );
+    }
+
     function testRevert_depositZeroAmount() public {
         vm.expectRevert(InvalidAmount.selector);
 


### PR DESCRIPTION
## Summary
- add test ensuring LibAsset.transferFromERC20 cannot move tokens without approval
- record tested vector for unauthorized transferFrom in TestedVectors

## Testing
- `forge test --match-path test/solidity/Libraries/LibAsset.t.sol --match-test transferFromERC20WithoutApproval -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a8e582c6d8832da05fa9085904114f