### PR TITLE
test: add algebra swap callback security tests

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -24,6 +24,8 @@
 |------|-------------|----------|--------|
 | 2025-02-14 | Unauthorized PancakeV3 swap callback invocation | High | Reverted with `UniswapV3SwapCallbackUnknownSource` |
 | 2025-02-14 | Zero or negative amount in PancakeV3 swap callback | Medium | Reverted with `UniswapV3SwapCallbackNotPositiveAmount` |
+| 2025-08-22 | Unauthorized Algebra swap callback invocation | High | Reverted with `UniswapV3SwapCallbackUnknownSource` |
+| 2025-08-22 | Zero or negative amount in Algebra swap callback | Medium | Reverted with `UniswapV3SwapCallbackNotPositiveAmount` |
 
 | Vector | Severity | Status | Notes |
 | ------ | -------- | ------ | ----- |

--- a/test/solidity/Periphery/LiFiDEXAggregator.t.sol
+++ b/test/solidity/Periphery/LiFiDEXAggregator.t.sol
@@ -2739,3 +2739,24 @@ contract LiFiDexAggregatorPancakeV3CallbackTest is Test {
         liFiDEXAggregator.pancakeV3SwapCallback(0, 0, abi.encode(address(0)));
     }
 }
+contract LiFiDexAggregatorAlgebraCallbackTest is Test {
+    LiFiDEXAggregator internal liFiDEXAggregator;
+
+    function setUp() public {
+        address[] memory privileged = new address[](1);
+        privileged[0] = address(this);
+        liFiDEXAggregator = new LiFiDEXAggregator(address(0), privileged, address(this));
+    }
+
+    function testRevert_AlgebraSwapCallbackUnknownSource() public {
+        vm.expectRevert(LiFiDEXAggregator.UniswapV3SwapCallbackUnknownSource.selector);
+        liFiDEXAggregator.algebraSwapCallback(1, 0, abi.encode(address(0)));
+    }
+
+    function testRevert_AlgebraSwapCallbackNotPositiveAmount() public {
+        vm.store(address(liFiDEXAggregator), bytes32(uint256(3)), bytes32(uint256(uint160(address(this)))));
+        vm.prank(address(this));
+        vm.expectRevert(LiFiDEXAggregator.UniswapV3SwapCallbackNotPositiveAmount.selector);
+        liFiDEXAggregator.algebraSwapCallback(0, 0, abi.encode(address(0)));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests ensuring Algebra swap callbacks cannot be abused
- document Algebra swap callback vectors in TestedVectors

## Testing
- `forge test --match-contract LiFiDexAggregatorAlgebraCallbackTest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e58530c8832db32db2e46e72da86