### PR TITLE
Add OmniBridge zero address constructor test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -206,3 +206,7 @@
 - Severity: Medium (privileged)
 - Test: `forge test --match-path test/solidity/Security/LiFiTimelockController.t.sol --match-test test_SetDiamondAddressAllowsZero`
 - Result: Admin can set `diamond` to `address(0)`, potentially disabling timelock functions; requires `TIMELOCK_ADMIN_ROLE` so not exploitable by unprivileged users.
+## OmniBridgeFacet constructor allows zero addresses
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/OmniBridgeFacetZero.t.sol`
+- Result: Contract deploys with zero `foreignOmniBridge` and `wethOmniBridge` addresses; bridge calls revert and tokens may be locked.

--- a/test/solidity/Security/OmniBridgeFacetZero.t.sol
+++ b/test/solidity/Security/OmniBridgeFacetZero.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {OmniBridgeFacet} from "lifi/Facets/OmniBridgeFacet.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+import {IOmniBridge} from "lifi/Interfaces/IOmniBridge.sol";
+
+contract OmniBridgeFacetZeroAddressTest is Test {
+    function test_ConstructorAllowsZeroAddresses() public {
+        OmniBridgeFacet facet = new OmniBridgeFacet(IOmniBridge(address(0)), IOmniBridge(address(0)));
+
+        ILiFi.BridgeData memory data = ILiFi.BridgeData({
+            transactionId: bytes32(""),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(0),
+            receiver: address(1),
+            minAmount: 1,
+            destinationChainId: 137,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        vm.expectRevert();
+        facet.startBridgeTokensViaOmniBridge{value: 1}(data);
+    }
+}


### PR DESCRIPTION
## Summary
- test OmniBridgeFacet for missing zero-address checks in constructor
- document OmniBridgeFacet zero-address issue in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/OmniBridgeFacetZero.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_68aa21635ba0832d855bd2a104f88263