### PR TITLE
test: add zero-address constructor tests

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -206,3 +206,17 @@
 - Severity: Medium (privileged)
 - Test: `forge test --match-path test/solidity/Security/LiFiTimelockController.t.sol --match-test test_SetDiamondAddressAllowsZero`
 - Result: Admin can set `diamond` to `address(0)`, potentially disabling timelock functions; requires `TIMELOCK_ADMIN_ROLE` so not exploitable by unprivileged users.
+## OmniBridgeFacet constructor allows zero addresses
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/OmniBridgeFacetZero.t.sol`
+- Result: Contract deploys with zero `foreignOmniBridge` and `wethOmniBridge` addresses, causing bridge calls to revert and leaving the facet unusable.
+
+## SymbiosisFacet constructor allows zero addresses
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/SymbiosisFacetZero.t.sol`
+- Result: Contract deploys with zero `symbiosisMetaRouter` and `symbiosisGateway` addresses; bridging attempts revert, rendering the facet inoperable.
+
+## LiFiDiamond constructor allows zero owner
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/LiFiDiamondZero.t.sol`
+- Result: Diamond initializes with owner set to `address(0)`, preventing future upgrades through `diamondCut`.

--- a/test/solidity/Security/LiFiDiamondZero.t.sol
+++ b/test/solidity/Security/LiFiDiamondZero.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {LiFiDiamond} from "lifi/LiFiDiamond.sol";
+import {DiamondCutFacet} from "lifi/Facets/DiamondCutFacet.sol";
+import {LibDiamond} from "lifi/Libraries/LibDiamond.sol";
+
+contract LiFiDiamondZeroOwnerTest is Test {
+    function test_ConstructorAllowsZeroOwner() public {
+        DiamondCutFacet diamondCut = new DiamondCutFacet();
+        LiFiDiamond diamond = new LiFiDiamond(address(0), address(diamondCut));
+
+        bytes32 position = keccak256("diamond.standard.diamond.storage");
+        address owner = address(uint160(uint256(vm.load(address(diamond), position))));
+        assertEq(owner, address(0), "owner should be zero");
+
+        LibDiamond.FacetCut[] memory cut;
+        vm.expectRevert();
+        DiamondCutFacet(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}

--- a/test/solidity/Security/OmniBridgeFacetZero.t.sol
+++ b/test/solidity/Security/OmniBridgeFacetZero.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {OmniBridgeFacet} from "lifi/Facets/OmniBridgeFacet.sol";
+import {IOmniBridge} from "lifi/Interfaces/IOmniBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract OmniBridgeFacetZeroAddressTest is Test {
+    function test_ConstructorAllowsZeroAddresses() public {
+        OmniBridgeFacet facet = new OmniBridgeFacet(IOmniBridge(address(0)), IOmniBridge(address(0)));
+
+        vm.deal(address(this), 1 ether);
+
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "omniBridge",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(0),
+            receiver: address(1),
+            minAmount: 1,
+            destinationChainId: block.chainid + 1,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        uint256 balanceBefore = address(this).balance;
+        vm.expectRevert();
+        facet.startBridgeTokensViaOmniBridge{value: 1}(bridgeData);
+        assertEq(address(this).balance, balanceBefore, "balance unchanged after revert");
+    }
+}

--- a/test/solidity/Security/SymbiosisFacetZero.t.sol
+++ b/test/solidity/Security/SymbiosisFacetZero.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {SymbiosisFacet} from "lifi/Facets/SymbiosisFacet.sol";
+import {ISymbiosisMetaRouter} from "lifi/Interfaces/ISymbiosisMetaRouter.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract SymbiosisFacetZeroAddressTest is Test {
+    function test_ConstructorAllowsZeroAddresses() public {
+        SymbiosisFacet facet = new SymbiosisFacet(ISymbiosisMetaRouter(address(0)), address(0));
+
+        vm.deal(address(this), 1 ether);
+
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "symbiosis",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(0),
+            receiver: address(1),
+            minAmount: 1,
+            destinationChainId: block.chainid + 1,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        address[] memory approved;
+        SymbiosisFacet.SymbiosisData memory sData = SymbiosisFacet.SymbiosisData({
+            firstSwapCalldata: "",
+            secondSwapCalldata: "",
+            intermediateToken: address(0),
+            firstDexRouter: address(0),
+            secondDexRouter: address(0),
+            approvedTokens: approved,
+            callTo: address(0),
+            callData: ""
+        });
+
+        uint256 balanceBefore = address(this).balance;
+        vm.expectRevert();
+        facet.startBridgeTokensViaSymbiosis{value: 1}(bridgeData, sData);
+        assertEq(address(this).balance, balanceBefore, "balance unchanged after revert");
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for OmniBridgeFacet constructor lacking address validation
- add SymbiosisFacet zero-address constructor test
- ensure LiFiDiamond cannot initialize with zero owner via test and record in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/OmniBridgeFacetZero.t.sol -vv`
- `forge test --match-path test/solidity/Security/SymbiosisFacetZero.t.sol -vv`
- `forge test --match-path test/solidity/Security/LiFiDiamondZero.t.sol -vv`


------
https://chatgpt.com/codex/tasks/task_e_68aa216509c8832da9fd134d642dfcfe