### PR TITLE
test: add zero address checks for across facets

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -128,10 +128,20 @@
 - Test: `forge test --match-path test/solidity/Security/StargateFacetV2Zero.t.sol`
 - Result: Contract deploys with `tokenMessaging` set to zero, preventing pool lookups and halting bridging.
 
+## AcrossFacet constructor allows zero addresses
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/AcrossFacetZero.t.sol`
+- Result: Contract deploys with `spokePool` and `wrappedNative` set to zero, causing bridge attempts to revert and rendering the facet unusable.
+
 ## AcrossFacetV3 constructor allows zero addresses
 - Severity: Medium
 - Test: `forge test --match-path test/solidity/Security/AcrossFacetV3Zero.t.sol`
 - Result: Contract deploys with `spokePool` and `wrappedNative` set to zero, leaving the facet unusable.
+
+## AcrossFacetPacked constructor allows zero addresses
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/AcrossFacetPackedZero.t.sol`
+- Result: Contract deploys with zero `spokePool` and `wrappedNative`, causing bridge attempts to revert and rendering the facet unusable.
 
 ## AcrossFacetPackedV3 constructor allows zero addresses
 - Severity: Medium

--- a/test/solidity/Security/AcrossFacetPackedZero.t.sol
+++ b/test/solidity/Security/AcrossFacetPackedZero.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {AcrossFacetPacked} from "lifi/Facets/AcrossFacetPacked.sol";
+import {IAcrossSpokePool} from "lifi/Interfaces/IAcrossSpokePool.sol";
+
+contract AcrossFacetPackedZeroAddressTest is Test {
+    AcrossFacetPacked facet;
+
+    function setUp() public {
+        facet = new AcrossFacetPacked(IAcrossSpokePool(address(0)), address(0), address(this));
+    }
+
+    function test_ConstructorAllowsZeroAddresses() public {
+        assertTrue(address(facet) != address(0));
+    }
+
+    function test_BridgeRevertsWithZeroConfig() public {
+        vm.expectRevert();
+        facet.startBridgeTokensViaAcrossNativeMin{value: 1 ether}(bytes32("tx"), address(0x1), 1, 0, 0, "", 0);
+    }
+}

--- a/test/solidity/Security/AcrossFacetZero.t.sol
+++ b/test/solidity/Security/AcrossFacetZero.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {AcrossFacet} from "lifi/Facets/AcrossFacet.sol";
+import {IAcrossSpokePool} from "lifi/Interfaces/IAcrossSpokePool.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract AcrossFacetZeroAddressTest is Test {
+    AcrossFacet facet;
+
+    function setUp() public {
+        facet = new AcrossFacet(IAcrossSpokePool(address(0)), address(0));
+    }
+
+    function test_ConstructorAllowsZeroAddresses() public {
+        // deployment succeeded with zero addresses
+        assertTrue(address(facet) != address(0));
+    }
+
+    function test_StartBridgeRevertsWithZeroConfig() public {
+        ILiFi.BridgeData memory data = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "Across",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(0),
+            receiver: address(0x1),
+            minAmount: 1 ether,
+            destinationChainId: 1,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+        AcrossFacet.AcrossData memory acrossData =
+            AcrossFacet.AcrossData({relayerFeePct: 0, quoteTimestamp: 0, message: "", maxCount: 0});
+        vm.expectRevert();
+        facet.startBridgeTokensViaAcross{value: 1 ether}(data, acrossData);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for AcrossFacet and AcrossFacetPacked zero address validation
- document results in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/AcrossFacetZero.t.sol`
- `forge test --match-path test/solidity/Security/AcrossFacetPackedZero.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e12106c832db614eeb3db6ed842