### PR TITLE
test: add chainflip zero receiver test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -270,3 +270,8 @@
 - Severity: Medium
 - Test: `forge test --match-path test/solidity/Security/GlacisFacetZeroRefundAddress.t.sol`
 - Result: `_startBridge` reverts with `InvalidRefundAddress` when `refundAddress` is zero, preventing misconfiguration.
+## ReceiverChainflip zero receiver burns funds
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/ReceiverChainflipZeroReceiver.t.sol`
+- Result: `cfReceive` accepts `receiver = address(0)` and transfers tokens to the zero address, permanently burning the funds.
+

--- a/test/solidity/Security/ReceiverChainflipZeroReceiver.t.sol
+++ b/test/solidity/Security/ReceiverChainflipZeroReceiver.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {LibSwap} from "lifi/Libraries/LibSwap.sol";
+import {ReceiverChainflip} from "lifi/Periphery/ReceiverChainflip.sol";
+import {IExecutor} from "lifi/Interfaces/IExecutor.sol";
+
+contract MockExecutor is IExecutor {
+    function swapAndCompleteBridgeTokens(bytes32, LibSwap.SwapData[] calldata, address, address payable)
+        external
+        payable
+        override
+    {
+        revert("fail");
+    }
+}
+
+contract ReceiverChainflipZeroReceiverTest is Test {
+    ReceiverChainflip internal receiver;
+    MockExecutor internal executor;
+    bytes32 internal guid = bytes32("12345");
+    address constant CHAINFLIP_NATIVE_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function setUp() public {
+        executor = new MockExecutor();
+        receiver = new ReceiverChainflip(address(this), address(executor), address(this));
+    }
+
+    function test_cfReceiveBurnsFundsOnZeroReceiver() public {
+        LibSwap.SwapData[] memory swapData = new LibSwap.SwapData[](1);
+        swapData[0] = LibSwap.SwapData({
+            callTo: address(0x1),
+            approveTo: address(0),
+            sendingAssetId: address(0),
+            receivingAssetId: address(0),
+            fromAmount: 1 ether,
+            callData: "",
+            requiresDeposit: false
+        });
+
+        bytes memory payload = abi.encode(guid, swapData, address(0));
+        uint256 preZeroBalance = address(0).balance;
+        receiver.cfReceive{value: 1 ether}(0, "", payload, CHAINFLIP_NATIVE_ADDRESS, 1 ether);
+        assertEq(address(0).balance, preZeroBalance + 1 ether);
+        assertEq(address(receiver).balance, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test for ReceiverChainflip zero-address receiver
- document new ReceiverChainflip vector

## Testing
- `forge test --match-path test/solidity/Security/ReceiverChainflipZeroReceiver.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e12106c832db614eeb3db6ed842