### PR TITLE
test: ensure DexManagerFacet rejects zero addresses

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -304,3 +304,7 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/HopFacetAllowance.t.sol`
 - Result: HopFacet leaves an unlimited allowance to the Hop bridge contract after bridging, enabling token drain if the bridge is compromised.
+## DexManagerFacet rejects zero DEX address
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/DexManagerFacetZero.t.sol`
+- Result: `addDex` reverts with `InvalidContract` when given the zero address, preventing misconfiguration of the DEX allow list.

--- a/test/solidity/Security/DexManagerFacetZero.t.sol
+++ b/test/solidity/Security/DexManagerFacetZero.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {DexManagerFacet} from "lifi/Facets/DexManagerFacet.sol";
+import {InvalidContract} from "lifi/Errors/GenericErrors.sol";
+
+contract DexManagerFacetZeroAddressTest is Test {
+    function test_addDexRevertsOnZeroAddress() public {
+        DexManagerFacet facet = new DexManagerFacet();
+        bytes32 namespace = keccak256("com.lifi.library.access.management");
+        bytes32 selectorSlot = keccak256(abi.encode(DexManagerFacet.addDex.selector, uint256(namespace)));
+        bytes32 accessSlot = keccak256(abi.encode(address(this), selectorSlot));
+        vm.store(address(facet), accessSlot, bytes32(uint256(1)));
+        vm.expectRevert(InvalidContract.selector);
+        facet.addDex(address(0));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add regression test verifying DexManagerFacet rejects zero-address DEX entries
- document tested attack vector in `TestedVectors.md`

## Testing
- `forge test --match-path test/solidity/Security/DexManagerFacetZero.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ab508ad0a4832dae6b79f1023ce3d6