### PR TITLE
Add PeripheryRegistryFacet zero address test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -356,3 +356,8 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/MayanFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaMayan` leaves an unlimited allowance to the Mayan router, enabling token drain via `transferFrom` if the router is compromised.
+## PeripheryRegistryFacet registers zero address
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/PeripheryRegistryFacetZero.t.sol`
+- Result: `registerPeripheryContract` accepts `address(0)` and stores it, enabling misconfiguration of registry entries.
+

--- a/test/solidity/Security/PeripheryRegistryFacetZero.t.sol
+++ b/test/solidity/Security/PeripheryRegistryFacetZero.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {PeripheryRegistryFacet} from "lifi/Facets/PeripheryRegistryFacet.sol";
+
+contract PeripheryRegistryFacetZeroAddressTest is Test {
+    PeripheryRegistryFacet facet;
+
+    function setUp() public {
+        facet = new PeripheryRegistryFacet();
+    }
+
+    function test_registerAllowsZeroAddress() public {
+        vm.prank(address(0));
+        facet.registerPeripheryContract("test", address(0));
+        assertEq(facet.getPeripheryContract("test"), address(0));
+    }
+}
+


### PR DESCRIPTION
## Summary
- record PeripheryRegistryFacet accepting zero addresses in registry
- add security test for PeripheryRegistryFacet zero address registration

## Testing
- `forge test --match-path test/solidity/Security/PeripheryRegistryFacetZero.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ab7eb6cd68832d89861e00c2e54852