### PR TITLE
Add tests for HopFacetOptimized allowance and LidoWrapper transfer failure

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -356,3 +356,13 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/MayanFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaMayan` leaves an unlimited allowance to the Mayan router, enabling token drain via `transferFrom` if the router is compromised.
+
+## HopFacetOptimized unlimited token allowance to bridge
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/HopFacetOptimizedAllowance.t.sol`
+- Result: HopFacetOptimized leaves an unlimited allowance to the Hop bridge, allowing a compromised bridge to drain tokens via `transferFrom`.
+
+## LidoWrapper wrap ignores failed transfer
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/LidoWrapperReturnFalse.t.sol`
+- Result: `wrapStETHToWstETH` ignores the return value of `transferFrom`, so wrapping succeeds even when token transfer fails, potentially misleading users.

--- a/test/solidity/Security/HopFacetOptimizedAllowance.t.sol
+++ b/test/solidity/Security/HopFacetOptimizedAllowance.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {HopFacetOptimized} from "lifi/Facets/HopFacetOptimized.sol";
+import {IHopBridge} from "lifi/Interfaces/IHopBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract MockHopBridge is IHopBridge {
+    address public token;
+    constructor(address _token) { token = _token; }
+    function sendToL2(
+        uint256,
+        address,
+        uint256 amount,
+        uint256,
+        uint256,
+        address,
+        uint256
+    ) external payable override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+    function swapAndSend(
+        uint256,
+        address,
+        uint256 amount,
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external payable override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+    function send(
+        uint256,
+        address,
+        uint256 amount,
+        uint256,
+        uint256,
+        uint256
+    ) external override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+    // malicious function to drain tokens using remaining allowance
+    function drain(address from, address to, uint256 amount) external {
+        MockERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract HopFacetOptimizedAllowanceTest is Test {
+    MockERC20 internal token;
+    MockHopBridge internal bridge;
+    HopFacetOptimized internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockHopBridge(address(token));
+        facet = new HopFacetOptimized();
+
+        address[] memory bridges = new address[](1);
+        address[] memory tokensToApprove = new address[](1);
+        bridges[0] = address(bridge);
+        tokensToApprove[0] = address(token);
+        vm.prank(address(0));
+        facet.setApprovalForBridges(bridges, tokensToApprove);
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 2,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        HopFacetOptimized.HopData memory hopData = HopFacetOptimized.HopData({
+            bonderFee: 0,
+            amountOutMin: 0,
+            deadline: block.timestamp + 1,
+            destinationAmountOutMin: 0,
+            destinationDeadline: block.timestamp + 1,
+            hopBridge: bridge,
+            relayer: address(0),
+            relayerFee: 0,
+            nativeFee: 0
+        });
+
+        facet.startBridgeTokensViaHopL1ERC20(bridgeData, hopData);
+
+        assertEq(token.allowance(address(facet), address(bridge)), type(uint256).max);
+
+        token.mint(address(facet), 5 ether);
+        bridge.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+

--- a/test/solidity/Security/LidoWrapperReturnFalse.t.sol
+++ b/test/solidity/Security/LidoWrapperReturnFalse.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import { LidoWrapper, IStETH } from "lifi/Periphery/LidoWrapper.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract FailingStETH is ERC20, IStETH {
+    constructor() ERC20("stETH", "stETH") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+    function wrap(uint256 amount) external override returns (uint256) { return amount; }
+    function unwrap(uint256 amount) external override returns (uint256) { return amount; }
+    function transfer(address, uint256) public pure override(ERC20, IERC20) returns (bool) { return false; }
+    function transferFrom(address, address, uint256) public pure override(ERC20, IERC20) returns (bool) { return false; }
+}
+
+contract MockWstETH is ERC20 {
+    constructor() ERC20("wstETH", "wstETH") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract LidoWrapperReturnFalseTest is Test {
+    LidoWrapper wrapper;
+    FailingStETH steth;
+    MockWstETH wsteth;
+
+    function setUp() public {
+        wsteth = new MockWstETH();
+        steth = new FailingStETH();
+        wrapper = new LidoWrapper(address(steth), address(wsteth), address(this));
+        steth.mint(address(this), 1 ether);
+        steth.approve(address(wrapper), type(uint256).max);
+    }
+
+    function test_WrapDoesNotRevertOnFailedTransferFrom() public {
+        uint256 balanceBefore = steth.balanceOf(address(this));
+        uint256 wrappedAmount = wrapper.wrapStETHToWstETH(1 ether);
+        assertEq(wrappedAmount, 0);
+        assertEq(steth.balanceOf(address(this)), balanceBefore);
+    }
+}
+


### PR DESCRIPTION
## Summary
- cover unlimited Hop bridge allowance in HopFacetOptimized
- document silent transfer failure in LidoWrapper

## Testing
- `forge test --match-path test/solidity/Security/HopFacetOptimizedAllowance.t.sol`
- `forge test --match-path test/solidity/Security/LidoWrapperReturnFalse.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ab7eb6cd68832d89861e00c2e54852