### PR TITLE
test: add OmniBridgeFacet allowance vulnerability

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -390,3 +390,7 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/GnosisBridgeFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaGnosisBridge` leaves an unlimited allowance to the Gnosis bridge router, enabling token drain via `transferFrom` if the router is compromised.
+## OmniBridgeFacet unlimited token allowance to bridge
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/OmniBridgeFacetAllowance.t.sol`
+- Result: `startBridgeTokensViaOmniBridge` leaves an unlimited allowance to the foreign OmniBridge contract, allowing a compromised bridge to drain any tokens later sent to the facet.

--- a/test/solidity/Security/OmniBridgeFacetAllowance.t.sol
+++ b/test/solidity/Security/OmniBridgeFacetAllowance.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {OmniBridgeFacet} from "lifi/Facets/OmniBridgeFacet.sol";
+import {IOmniBridge} from "lifi/Interfaces/IOmniBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract MockOmniBridge is IOmniBridge {
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function relayTokens(
+        address _token,
+        address,
+        uint256 _amount
+    ) external override {
+        MockERC20(_token).transferFrom(msg.sender, address(this), _amount);
+    }
+
+    function wrapAndRelayTokens(address) external payable override {}
+
+    // malicious function to drain tokens using remaining allowance
+    function drain(address from, address to, uint256 amount) external {
+        MockERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract OmniBridgeFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockOmniBridge internal bridge;
+    OmniBridgeFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockOmniBridge(address(token));
+        facet = new OmniBridgeFacet(IOmniBridge(address(bridge)), IOmniBridge(address(bridge)));
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 2,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        facet.startBridgeTokensViaOmniBridge(bridgeData);
+
+        assertEq(token.allowance(address(facet), address(bridge)), type(uint256).max);
+
+        token.mint(address(facet), 5 ether);
+        bridge.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add OmniBridgeFacet allowance security test
- record OmniBridgeFacet unlimited allowance in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/OmniBridgeFacetAllowance.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ace782df04832d9c731b75d735d7c4