### PR TITLE
test: add OptimismBridgeFacet allowance test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -184,6 +184,7 @@
 - Test: `forge test --match-path test/solidity/Security/CelerCircleBridgeFacetZero.t.sol`
 - Result: Contract deploys with zero `circleBridgeProxy` and `usdc` addresses; calls to `startBridgeTokensViaCelerCircleBridge` succeed but leave tokens stuck in the contract.
 
+
 ## OptimismBridgeFacet initialization allows zero standard bridge
 - Severity: Medium
 - Test: `forge test --match-path test/solidity/Security/OptimismBridgeFacetZeroStandardBridge.t.sol`
@@ -390,3 +391,9 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/GnosisBridgeFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaGnosisBridge` leaves an unlimited allowance to the Gnosis bridge router, enabling token drain via `transferFrom` if the router is compromised.
+
+## OptimismBridgeFacet unlimited token allowance to bridge
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/OptimismBridgeFacetAllowance.t.sol`
+- Result: `startBridgeTokensViaOptimismBridge` leaves an unlimited allowance to the Optimism standard bridge, enabling token drain via `transferFrom` if the bridge is compromised.
+

--- a/test/solidity/Security/OptimismBridgeFacetAllowance.t.sol
+++ b/test/solidity/Security/OptimismBridgeFacetAllowance.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {OptimismBridgeFacet} from "lifi/Facets/OptimismBridgeFacet.sol";
+import {IL1StandardBridge} from "lifi/Interfaces/IL1StandardBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+import {LibDiamond} from "lifi/Libraries/LibDiamond.sol";
+
+contract MockStandardBridge is IL1StandardBridge {
+    function depositETHTo(address, uint32, bytes calldata) external payable override {}
+
+    function depositERC20To(
+        address l1Token,
+        address,
+        address,
+        uint256 amount,
+        uint32,
+        bytes calldata
+    ) external override {
+        MockERC20(l1Token).transferFrom(msg.sender, address(this), amount);
+    }
+
+    function depositTo(address, uint256) external override {}
+
+    function drain(
+        MockERC20 token,
+        address from,
+        address to,
+        uint256 amount
+    ) external {
+        token.transferFrom(from, to, amount);
+    }
+}
+
+contract TestOptimismFacet is OptimismBridgeFacet {
+    function initOwner() external {
+        LibDiamond.setContractOwner(msg.sender);
+    }
+}
+
+contract OptimismBridgeFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockStandardBridge internal bridge;
+    TestOptimismFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockStandardBridge();
+        facet = new TestOptimismFacet();
+        facet.initOwner();
+        OptimismBridgeFacet.Config[] memory configs = new OptimismBridgeFacet.Config[](0);
+        facet.initOptimism(configs, IL1StandardBridge(address(bridge)));
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: attacker,
+            minAmount: 10 ether,
+            destinationChainId: 10,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        OptimismBridgeFacet.OptimismData memory optData = OptimismBridgeFacet.OptimismData({
+            assetIdOnL2: address(0),
+            l2Gas: 0,
+            isSynthetix: false
+        });
+
+        facet.startBridgeTokensViaOptimismBridge(bridgeData, optData);
+
+        assertEq(
+            token.allowance(address(facet), address(bridge)),
+            type(uint256).max
+        );
+
+        token.mint(address(facet), 5 ether);
+        bridge.drain(token, address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add regression test for unlimited allowance in OptimismBridgeFacet
- document OptimismBridgeFacet allowance vector

## Testing
- `forge test --match-path test/solidity/Security/OptimismBridgeFacetAllowance.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ace7847bf8832d8af5b5be70e1c292