### PR TITLE
Document coverage for AccessManager and calldata checks

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -426,3 +426,13 @@
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/OptimismBridgeFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaOptimismBridge` leaves an unlimited allowance to the Optimism standard bridge, enabling token drain via `transferFrom` if the bridge is compromised.
+## AccessManagerFacet unauthorized access
+- Severity: High
+- Test: `forge test --match-path test/solidity/Facets/AccessManagerFacet.t.sol --match-test testRevert_FailsIfNonOwnerTriesToGrantAccess`
+- Result: Non-owner calls to `setCanExecute` revert with `OnlyContractOwner`, preventing privilege escalation.
+
+## CalldataVerificationFacet rejects short generic swap calldata
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Facets/CalldataVerificationFacet.t.sol --match-test test_RevertsOnInvalidGenericSwapCallData`
+- Result: `extractGenericSwapParameters` reverts with `InvalidCallData` when calldata is under 484 bytes, blocking malformed swap requests.
+


### PR DESCRIPTION
## Summary
- record AccessManagerFacet authorization protection
- note CalldataVerificationFacet rejection of short generic swap calldata

## Testing
- `forge test --match-path test/solidity/Facets/AccessManagerFacet.t.sol --match-test testRevert_FailsIfNonOwnerTriesToGrantAccess` *(fails: environment variable "ETH_NODE_URI_MAINNET" not found)*
- `forge test --match-path test/solidity/Facets/CalldataVerificationFacet.t.sol --match-test test_RevertsOnInvalidGenericSwapCallData` *(fails: environment variable "ETH_NODE_URI_MAINNET" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0a6c670832dbc49e4233298ac8c