### PR TITLE
test: ensure GasZipFacet rejects zero router

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -116,6 +116,11 @@
 - Test: `forge test --match-path test/solidity/Security/GasZipPeripheryZero.t.sol`
 - Result: Contract deploys with zero `gasZipRouter` and `liFiDEXAggregator`, leaving operations unusable and risking fund lockup.
 
+## GasZipFacet constructor rejects zero router address
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Security/GasZipFacetZero.t.sol`
+- Result: Constructor reverts with `InvalidConfig` when `gasZipRouter` is the zero address, preventing misconfiguration.
+
 ## RelayFacet startBridgeTokensViaRelay reentrancy
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/RelayFacetReentrancyStart.t.sol`

--- a/test/solidity/Security/GasZipFacetZero.t.sol
+++ b/test/solidity/Security/GasZipFacetZero.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {GasZipFacet} from "lifi/Facets/GasZipFacet.sol";
+import {InvalidConfig} from "lifi/Errors/GenericErrors.sol";
+
+contract GasZipFacetZeroTest is Test {
+    function test_constructor_reverts_on_zero_router() public {
+        vm.expectRevert(InvalidConfig.selector);
+        new GasZipFacet(address(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add security test verifying GasZipFacet constructor rejects zero router address
- document gaszip facet constructor check in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/GasZipFacetZero.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_68adf0a7fd28832d8166d373f8ba428a