### PR TITLE
test: add across facet allowance test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -452,6 +452,11 @@
 - Test: `forge test --match-path test/solidity/Security/ArbitrumBridgeFacetAllowance.t.sol`
 - Result: `startBridgeTokensViaArbitrumBridge` leaves an unlimited allowance to the gateway router, allowing a compromised router to drain tokens from the facet.
 
+## AcrossFacet unlimited token allowance to spoke pool
+- Severity: High
+- Test: `forge test --match-path test/solidity/Security/AcrossFacetAllowance.t.sol`
+- Result: `startBridgeTokensViaAcross` leaves an unlimited allowance to the Across spoke pool, allowing a compromised pool to drain tokens from the facet.
+
 ## AccessManagerFacet unauthorized access
 - Severity: High
 - Test: `forge test --match-path test/solidity/Facets/AccessManagerFacet.t.sol --match-test testRevert_FailsIfNonOwnerTriesToGrantAccess`

--- a/test/solidity/Security/AcrossFacetAllowance.t.sol
+++ b/test/solidity/Security/AcrossFacetAllowance.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {AcrossFacet} from "lifi/Facets/AcrossFacet.sol";
+import {IAcrossSpokePool} from "lifi/Interfaces/IAcrossSpokePool.sol";
+import {ILiFi} from "lifi/Interfaces/ILiFi.sol";
+
+contract MockAcrossSpokePool is IAcrossSpokePool {
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function deposit(address, address, uint256 amount, uint256, int64, uint32, bytes memory, uint256)
+        external
+        payable
+        override
+    {
+        MockERC20(token).transferFrom(msg.sender, address(this), amount);
+    }
+
+    function depositV3(
+        address,
+        address,
+        address,
+        address,
+        uint256 inputAmount,
+        uint256,
+        uint256,
+        address,
+        uint32,
+        uint32,
+        uint32,
+        bytes calldata
+    ) external payable override {
+        MockERC20(token).transferFrom(msg.sender, address(this), inputAmount);
+    }
+
+    // malicious function to drain leftover allowance
+    function drain(address from, address to, uint256 amount) external {
+        MockERC20(token).transferFrom(from, to, amount);
+    }
+}
+
+contract AcrossFacetAllowanceTest is Test {
+    MockERC20 internal token;
+    MockAcrossSpokePool internal bridge;
+    AcrossFacet internal facet;
+    address internal attacker = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("Mock", "MOCK", 18);
+        bridge = new MockAcrossSpokePool(address(token));
+        facet = new AcrossFacet(IAcrossSpokePool(address(bridge)), address(0));
+        token.mint(address(this), 100 ether);
+        token.approve(address(facet), type(uint256).max);
+    }
+
+    function test_UnlimitedAllowanceAllowsTokenDrain() public {
+        ILiFi.BridgeData memory bridgeData = ILiFi.BridgeData({
+            transactionId: bytes32("tx"),
+            bridge: "Across",
+            integrator: "",
+            referrer: address(0),
+            sendingAssetId: address(token),
+            receiver: address(0x1234),
+            minAmount: 10 ether,
+            destinationChainId: 1,
+            hasSourceSwaps: false,
+            hasDestinationCall: false
+        });
+
+        AcrossFacet.AcrossData memory acrossData =
+            AcrossFacet.AcrossData({relayerFeePct: 0, quoteTimestamp: 0, message: "", maxCount: 0});
+
+        facet.startBridgeTokensViaAcross{value: 0}(bridgeData, acrossData);
+
+        // allowance remains after bridging
+        assertEq(token.allowance(address(facet), address(bridge)), type(uint256).max);
+
+        // attacker sends tokens to facet and bridge drains them
+        token.mint(address(facet), 5 ether);
+        bridge.drain(address(facet), attacker, 5 ether);
+
+        assertEq(token.balanceOf(attacker), 5 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- add security regression test for AcrossFacet unlimited allowance
- document leftover token approval to spoke pool in TestedVectors

## Testing
- `forge test --match-path test/solidity/Security/AcrossFacetAllowance.t.sol --via-ir`

------
https://chatgpt.com/codex/tasks/task_e_68af82940bf4832d8af11db2cfa57228