### PR TITLE
docs: document GasZipFacet zero receiver check

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,6 +127,11 @@
 - Test: `forge test --match-path test/solidity/Security/GasZipFacetZero.t.sol`
 - Result: Constructor reverts with `InvalidConfig` when `gasZipRouter` is the zero address, preventing misconfiguration.
 
+## GasZipFacet zero receiver burns funds
+- Severity: Medium
+- Test: `forge test --match-path test/solidity/Facets/GasZipFacet.t.sol --match-test testBase_Revert_BridgeWithInvalidReceiverAddress`
+- Result: Reverts with `InvalidCallData` when `receiverAddress` is zero, preventing accidental burning of bridged assets.
+
 ## RelayFacet startBridgeTokensViaRelay reentrancy
 - Severity: High
 - Test: `forge test --match-path test/solidity/Security/RelayFacetReentrancyStart.t.sol`


### PR DESCRIPTION
## Summary
- document that GasZipFacet rejects zero receiver addresses

## Testing
- `forge test --match-path test/solidity/Facets/GasZipFacet.t.sol --match-test testBase_Revert_BridgeWithInvalidReceiverAddress`

------
https://chatgpt.com/codex/tasks/task_e_68af82940bf4832d8af11db2cfa57228